### PR TITLE
Update version to 4.1.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.hubspot</groupId>
   <artifactId>netty-all-41</artifactId>
-  <version>4.1.8-SNAPSHOT</version>
+  <version>4.1.30-SNAPSHOT</version>
 
   <scm>
     <connection>scm:git:git@github.com:HubSpot/netty-41.git</connection>
@@ -28,7 +28,7 @@
 
   <properties>
     <basepom.check.skip-dependency>true</basepom.check.skip-dependency>
-    <hubspot.netty41.version>4.1.8.Final</hubspot.netty41.version>
+    <hubspot.netty41.version>4.1.30.Final</hubspot.netty41.version>
     <hubspot.pom.path>${project.build.directory}/${project.artifactId}-${project.version}.pom</hubspot.pom.path>
   </properties>
 


### PR DESCRIPTION
This is the version vitess and GRPC are on now so it would be good to match them.

@axiak 