### PR TITLE
Netty41 upgrade to 4.1.89.Final

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Maven:
     <dependency>
       <groupId>com.hubspot</groupId>
       <artifactId>netty-all-41</artifactId>
-      <version>4.1.68-SNAPSHOT</version>
+      <version>4.1.89-SNAPSHOT</version>
       <classifier>shaded</classifier>
     </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -9,11 +9,11 @@
   </parent>
 
   <artifactId>netty-all-41</artifactId>
-  <version>4.1.89-SNAPSHOT</version>
+  <version>4.1.68-SNAPSHOT</version>
 
   <properties>
     <basepom.check.skip-dependency>true</basepom.check.skip-dependency>
-    <hubspot.netty41.version>4.1.89.Final</hubspot.netty41.version>
+    <hubspot.netty41.version>4.1.68.Final</hubspot.netty41.version>
     <hubspot.pom.path>${project.build.directory}/${project.artifactId}-${project.version}.pom</hubspot.pom.path>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,15 +5,15 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>25.6</version>
+    <version>25.7</version>
   </parent>
 
   <artifactId>netty-all-41</artifactId>
-  <version>4.1.68-SNAPSHOT</version>
+  <version>4.1.89-SNAPSHOT</version>
 
   <properties>
     <basepom.check.skip-dependency>true</basepom.check.skip-dependency>
-    <hubspot.netty41.version>4.1.68.Final</hubspot.netty41.version>
+    <hubspot.netty41.version>4.1.89.Final</hubspot.netty41.version>
     <hubspot.pom.path>${project.build.directory}/${project.artifactId}-${project.version}.pom</hubspot.pom.path>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,18 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>com.hubspot</groupId>
-    <artifactId>basepom</artifactId>
-    <version>25.7</version>
-  </parent>
-
+  <groupId>com.hubspot</groupId>
   <artifactId>netty-all-41</artifactId>
-  <version>4.1.68-SNAPSHOT</version>
+  <version>4.1.89-SNAPSHOT</version>
 
   <properties>
     <basepom.check.skip-dependency>true</basepom.check.skip-dependency>
-    <hubspot.netty41.version>4.1.68.Final</hubspot.netty41.version>
+    <hubspot.netty41.version>4.1.89.Final</hubspot.netty41.version>
     <hubspot.pom.path>${project.build.directory}/${project.artifactId}-${project.version}.pom</hubspot.pom.path>
   </properties>
 


### PR DESCRIPTION
Testing some things related to arm64 upgrades. arm64 support was added in 4.1.50, and the native library links are gtg after upgrading to 4.1.68. _But_ we instead encountered some odd epoll errors in certain email imap usages causing sporadic errors and connection issues (similar to [this](https://stackoverflow.com/questions/33151503/epoll-ctl-failed-no-such-file-or-directory-errno-2) but likely other root cause). There are a number of epoll-related updates in 70, 76, 77, 80, 83, and 88 that I am hopefull will solve the issue.

aside: It seems like they restructued the pom of netty-all, making a number of things conflict with basepom. Given this is a shaded jar, my thought is that it shouldn't be on basepom anyway (seems there was a similar comment last PR) so removed that for now.