### PR TITLE
Include all jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,11 +64,6 @@
               <dependencyReducedPomLocation>${hubspot.pom.path}</dependencyReducedPomLocation>
               <useBaseVersion>true</useBaseVersion>
               <shadedArtifactAttached>true</shadedArtifactAttached>
-              <artifactSet>
-                <includes>
-                  <include>*:*</include>
-                </includes>
-              </artifactSet>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <artifactSet>
                 <includes>
-                  <include>io.netty:netty-all</include>
+                  <include>*:*</include>
                 </includes>
               </artifactSet>
               <filters>


### PR DESCRIPTION
4.1.69 onward, netty-all isn't an uber jar by default. Include all dependencies in the shaded jar here